### PR TITLE
Convert streams from str to byte for reportlab

### DIFF
--- a/pdfrw/toreportlab.py
+++ b/pdfrw/toreportlab.py
@@ -53,6 +53,7 @@ Notes:
 
 from reportlab.pdfbase import pdfdoc as rldocmodule
 from .objects import PdfDict, PdfArray, PdfName
+from .py23_diffs import convert_store
 
 RLStream = rldocmodule.PDFStream
 RLDict = rldocmodule.PDFDictionary
@@ -74,7 +75,7 @@ def _makedict(rldoc, pdfobj):
 
 def _makestream(rldoc, pdfobj, xobjtype=PdfName.XObject):
     rldict = RLDict()
-    rlobj = RLStream(rldict, pdfobj.stream)
+    rlobj = RLStream(rldict, convert_store(pdfobj.stream))
 
     if pdfobj.Type == xobjtype:
         shortname = 'pdfrw_%s' % (rldoc.objectcounter + 1)


### PR DESCRIPTION
Testing with examples/rl1/subset.py showed that streams were not being properly sent to reportlab under Python 3.

There may be other issues with regular text (unicode issues), but this small change lets several files work properly.
