### PR TITLE
rotations don't work in Py3

### DIFF
--- a/pdfrw/buildxobj.py
+++ b/pdfrw/buildxobj.py
@@ -83,7 +83,7 @@ def get_rotation(rotate):
         return 0
     if rotate % 90 != 0:
         return 0
-    return rotate / 90
+    return int(rotate / 90)
 
 
 def rotate_point(point, rotation):


### PR DESCRIPTION
In Python 3, `float / int == float`, so the return value from `get_rotation` will usually be a float.  In `rotate_point`, however, `float & int` is a `TypeError`, so `rotation & 1` fails when `rotation` is a float.  Therefore, for any rotation that is valid in `get_rotation`, `rotate_rect` will raise a `TypeError`.