### PR TITLE
Make all tests run on TravisCI:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,8 @@ before_install:
   - "git clone https://github.com/pmaupin/static_pdfs tests/static_pdfs"
 install:
   - "pip install ."
+  - "pip install reportlab || true"
+  - "pip install zlib || true"
+  - "pip install unittest2 || true"
 # command to run tests
-script: "cd tests; py.test"
+script: "cd tests; /usr/bin/env PYTHONPATH=. py.test"

--- a/examples/rl1/4up.py
+++ b/examples/rl1/4up.py
@@ -13,8 +13,6 @@ Demonstrates use of pdfrw with reportlab.
 import sys
 import os
 
-import invariant
-
 from reportlab.pdfgen.canvas import Canvas
 
 from pdfrw import PdfReader

--- a/examples/rl1/booklet.py
+++ b/examples/rl1/booklet.py
@@ -13,8 +13,6 @@ Demonstrates use of pdfrw with reportlab.
 import sys
 import os
 
-import invariant
-
 from reportlab.pdfgen.canvas import Canvas
 
 from pdfrw import PdfReader

--- a/examples/rl1/invariant.py
+++ b/examples/rl1/invariant.py
@@ -1,6 +1,0 @@
-import reportlab.rl_settings
-
-# Keep reportlab from changing the date on us,
-# so that we can get a fix on the MD5.
-
-reportlab.rl_settings.invariant = True

--- a/examples/rl1/platypus_pdf_template.py
+++ b/examples/rl1/platypus_pdf_template.py
@@ -14,8 +14,6 @@ Contributed by user asannes
 import sys
 import os
 
-import invariant
-
 from reportlab.platypus import PageTemplate, BaseDocTemplate, Frame
 from reportlab.platypus import NextPageTemplate, Paragraph, PageBreak
 from reportlab.platypus.tableofcontents import TableOfContents
@@ -87,7 +85,7 @@ def create_toc():
 
 def create_pdf(filename, pdf_template_filename):
     """Create the pdf, with all the contents"""
-    pdf_report = open(filename, "w")
+    pdf_report = open(filename, "wb")
     document = MyDocTemplate(pdf_report)
     templates = [MyTemplate(pdf_template_filename, name='background')]
     document.addPageTemplates(templates)

--- a/examples/rl1/subset.py
+++ b/examples/rl1/subset.py
@@ -15,8 +15,6 @@ Demonstrates use of pdfrw with reportlab.
 import sys
 import os
 
-import invariant
-
 from reportlab.pdfgen.canvas import Canvas
 
 from pdfrw import PdfReader

--- a/pdfrw/objects/pdfstring.py
+++ b/pdfrw/objects/pdfstring.py
@@ -67,10 +67,6 @@ class PdfString(str):
 
     def encode(cls, source, usehex=False):
         assert not usehex, "Not supported yet"
-        if isinstance(source, unicode):
-            source = source.encode('utf-8')
-        else:
-            source = str(source)
         source = source.replace('\\', '\\\\')
         source = source.replace('(', '\\(')
         source = source.replace(')', '\\)')

--- a/tests/expected.txt
+++ b/tests/expected.txt
@@ -20,10 +20,10 @@ examples/subset_1975ef8db7355b1d691bc79d0749574b_21     5057f345f1a1109a0e54276a
 examples/rotate_5057f345f1a1109a0e54276a68e8f8df_90_1   881f4dc8dcf069e707bf61af95492d86
 examples/poster_881f4dc8dcf069e707bf61af95492d86        a34be06d22105b6c02394a9f278fec0d
 
-examples/rl1/platypus_pdf_template_b1c400de699af29ea3f1983bb26870ab ec98c37e11441ee3b24e79006f6327c4
-examples/rl1/4up_b1c400de699af29ea3f1983bb26870ab                   3fbc6062ddd008a61f11ade2434336f1
-examples/rl1/booklet_b1c400de699af29ea3f1983bb26870ab               997130df3da157a19be0024143402bc5
-examples/rl1/subset_b1c400de699af29ea3f1983bb26870ab_3_5            7bbea500c5af6f19f468efb12c375c47
+examples/rl1/4up_b1c400de699af29ea3f1983bb26870ab                   959d6246ad8bda72bd023e8681216d17
+examples/rl1/booklet_b1c400de699af29ea3f1983bb26870ab               45b4ae29a038271896b7264bbed63bdf
+examples/rl1/subset_b1c400de699af29ea3f1983bb26870ab_3_5            822bce1cb9e053f1f3f6b922bf27fab8
+examples/rl1/platypus_pdf_template_b1c400de699af29ea3f1983bb26870ab 97ad6a8ca3fe7cc4e1f0ffb8475355e9
 
 # List things that need work here (typically cause exceptions)
 

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -28,13 +28,17 @@ In order to use them:
 
 '''
 import os
-import unittest
 import hashlib
 import pdfrw
 import static_pdfs
 import expected
 
 from pdfrw.py23_diffs import convert_store
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 
 class TestOnePdf(unittest.TestCase):


### PR DESCRIPTION
  - Remove reportlab invariant, because it's broken (files are not
    invariant anyway) under Python 3.
  - Instead, canonicalize output from reportlab by passing it
    back through pdfrw before comparison.
  - Fix dependencies (reportlab, zlib, unittest2, etc.)
  - Fix MD5 checksums for reportlab output