### PR TITLE
handle unicode string

### DIFF
--- a/pdfrw/objects/pdfstring.py
+++ b/pdfrw/objects/pdfstring.py
@@ -13,13 +13,13 @@ class PdfString(str):
         defaults to being a direct object.
     '''
     indirect = False
-    unescape_dict = {'\\b': '\b', '\\f': '\f', '\\n': '\n',
-                     '\\r': '\r', '\\t': '\t',
-                     '\\\r\n': '', '\\\r': '', '\\\n': '',
-                     '\\\\': '\\', '\\': '',
-                     }
+    unescape_dict = {'\\b':'\b', '\\f':'\f', '\\n':'\n',
+                     '\\r':'\r', '\\t':'\t',
+                     '\\\r\n': '', '\\\r':'', '\\\n':'',
+                     '\\\\':'\\', '\\':'', '\\(': '(', '\\)':')'
+                    }
     unescape_pattern = (r'(\\\\|\\b|\\f|\\n|\\r|\\t'
-                        r'|\\\r\n|\\\r|\\\n|\\[0-9]+|\\)')
+                        r'|\\\r\n|\\\r|\\\n|\\[0-9]{3}|\\)')
     unescape_func = re.compile(unescape_pattern).split
 
     hex_pattern = '([a-fA-F0-9][a-fA-F0-9]|[a-fA-F0-9])'
@@ -41,8 +41,8 @@ class PdfString(str):
             if chunk.startswith('\\') and len(chunk) > 1:
                 value = int(chunk[1:], 8)
                 # FIXME: TODO: Handle unicode here
-                if value > 127:
-                    value = 127
+                if value > 255:
+                    value = 255
                 chunk = remap(value)
             if chunk:
                 result.append(chunk)


### PR DESCRIPTION
Fix a few regular expression for pdf string.
My project https://github.com/tjwei/translatePDF uses pdfrw and handling a lot of unicode pdf string.
This is a patch that works for handling various Chinese string in pdf.
This patch fixed the following issue:
(\0160) should be parsed as \016 0 not oct(0160), so it should be decoded into \xe30 not max(int(1600, 8), 127).
