### PR TITLE
Fix booklet example: add blank pages for correct impositio

### DIFF
--- a/examples/booklet.py
+++ b/examples/booklet.py
@@ -25,15 +25,18 @@ inpfn, = sys.argv[1:]
 outfn = 'booklet.' + os.path.basename(inpfn)
 ipages = PdfReader(inpfn).pages
 
-# Make sure we have an even number
-if len(ipages) & 1:
-    ipages.append(None)
+# Create blank page
+blank = PageMerge()
+blank.mbox = ipages[0].MediaBox
+blank = blank.render()
+
+# Make sure we have a multiple of 4 pages
+while len(ipages) % 4:
+    ipages.append(blank)
 
 opages = []
-while len(ipages) > 2:
+while ipages:
     opages.append(fixpage(ipages.pop(), ipages.pop(0)))
     opages.append(fixpage(ipages.pop(0), ipages.pop()))
-
-opages += ipages
 
 PdfWriter().addpages(opages).write(outfn)


### PR DESCRIPTION
This patch pads the input PDF file with blank pages, until its page count is a multiple of 4. It fixes a bug in example/booklet.py: if the page count is not a multiple of 4, remaining pages are added without being merged in fixpage()
