### PR TITLE
Fix logging (do not touch root logger)

### DIFF
--- a/pdfrw/errors.py
+++ b/pdfrw/errors.py
@@ -9,11 +9,14 @@ PDF Exceptions and error handling
 import logging
 
 
-logging.basicConfig(
-    format='[%(levelname)s] %(filename)s:%(lineno)d %(message)s',
-           level=logging.WARNING)
+fmt = logging.Formatter('[%(levelname)s] %(filename)s:%(lineno)d %(message)s')
+
+handler = logging.StreamHandler()
+handler.setFormatter(fmt)
 
 log = logging.getLogger('pdfrw')
+log.setLevel(logging.WARNING)
+log.addHandler(handler)
 
 
 class PdfError(Exception):


### PR DESCRIPTION
The call to `logging.basicConfig` set the root logger, which is problematic for a library: when importing from another place - typically an application - I don't want one of the dependencies/libraries to mess with my root logger.

The proposed fix does exactly the same thing (setting logging level and formatter), except it only does so for the pdfrw logger.