### PR TITLE
Partially implement handling of Unicode strings in PDF

### DIFF
--- a/examples/alter.py
+++ b/examples/alter.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 '''
 usage:   alter.py my.pdf
@@ -6,6 +7,7 @@ usage:   alter.py my.pdf
 Creates alter.my.pdf
 
 Demonstrates making a slight alteration to a preexisting PDF file.
+Also demonstrates Unicode support.
 
 '''
 
@@ -18,7 +20,7 @@ inpfn, = sys.argv[1:]
 outfn = 'alter.' + os.path.basename(inpfn)
 
 trailer = PdfReader(inpfn)
-trailer.Info.Title = 'My New Title Goes Here'
+trailer.Info.Title = 'My New Title Goes Here - 我的新名称在这儿'
 writer = PdfWriter()
 writer.trailer = trailer
 writer.write(outfn)

--- a/pdfrw/objects/pdfstring.py
+++ b/pdfrw/objects/pdfstring.py
@@ -32,7 +32,7 @@ class PdfString(str):
             chunk = unescape(chunk, chunk)
             if chunk.startswith('\\') and len(chunk) > 1:
                 value = int(chunk[1:], 8)
-                # FIXME: TODO: Handle unicode here
+                # FIXME: TODO: Handle PDFDocEncoding
                 if value > 255:
                     value = 255
                 chunk = remap(value)
@@ -64,7 +64,8 @@ class PdfString(str):
             # Encode a Unicode string as UTF-16 big endian, in bytes
             utf16_bytes = source.encode('utf-16be')
             # Prepend byte order mark and encode bytes as hexadecimal
-            ascii_hex_bytes = codecs.encode(b'\xfe\xff' + utf16_bytes, 'hex')
+            ascii_hex_bytes = codecs.encode(
+                codecs.BOM_UTF16_BE + utf16_bytes, 'hex')
             # Decode hexadecimal bytes to ASCII
             ascii_hex_str = ascii_hex_bytes.decode('ascii').lower()
             return cls('<' + ascii_hex_str + '>')


### PR DESCRIPTION
This teaches pdfrw to handle Unicode to a certain extent: if a string cannot be encoded as ASCII, encoded it as PDF hex-encoded ASCII string like <ffee00aa>.

This is incomplete because it doesn't handle PDFDocEncoding, and really you'd need to distinguish between byte strings and text strings, and I don't know enough about this project to overhaul it to that degree. PyPDF2 incidentally does have this implemented.
