### PR TITLE
pagemerge: fix XObject search for /pdfrw_ keys

### DIFF
--- a/pdfrw/pagemerge.py
+++ b/pdfrw/pagemerge.py
@@ -199,9 +199,9 @@ class PageMerge(list):
             allkeys = xobjs.keys()
             if allkeys:
                 keys = (x for x in allkeys if x.startswith('/pdfrw_'))
-                keys = (x for x in keys if x[6:].isdigit())
-                keys = sorted(keys, key=lambda x: int(x[6:]))
-                key_offset = (int(keys[-1][6:]) + 1) if keys else 0
+                keys = (x for x in keys if x[7:].isdigit())
+                keys = sorted(keys, key=lambda x: int(x[7:]))
+                key_offset = (int(keys[-1][7:]) + 1) if keys else 0
                 key_offset -= len(allkeys)
 
         if old_contents is None:


### PR DESCRIPTION
String length of /pdfrw_ should be 7, was 6.

The issue manifests as KeyError: 'XObj key /pdfrw_0 already in use'. Can be triggered when processing files that have already been through pdfrw.