### PR TITLE
pdfwriter: update page-referring objects

### DIFF
--- a/pdfrw/pdfwriter.py
+++ b/pdfrw/pdfwriter.py
@@ -44,7 +44,7 @@ def user_fmt(obj, isinstance=isinstance, float=float, str=str,
     return str(obj)
 
 
-def FormatObjects(f, trailer, version='1.3', compress=True, killobj=(),
+def FormatObjects(f, trailer, version='1.3', compress=True, killobj=(), objmap={},
                   user_fmt=user_fmt, do_compress=do_compress,
                   convert_store=convert_store, iteritems=iteritems,
                   id=id, isinstance=isinstance, getattr=getattr, len=len,
@@ -65,6 +65,10 @@ def FormatObjects(f, trailer, version='1.3', compress=True, killobj=(),
         '''
         # Can't hash dicts, so just hash the object ID
         objid = id(obj)
+
+        while objid in objmap:
+            obj = objmap[objid]
+            objid = id(obj)
 
         # Automatically set stream objects to indirect
         if isinstance(obj, PdfDict):
@@ -231,6 +235,7 @@ class PdfWriter(object):
         self.compress = compress
         self.version = version
         self.killobj = {}
+        self.pagemap = {}
 
     def addpage(self, page):
         self._trailer = None
@@ -238,15 +243,15 @@ class PdfWriter(object):
             raise PdfOutputError('Bad /Type:  Expected %s, found %s'
                                  % (PdfName.Page, page.Type))
         inheritable = page.inheritable  # searches for resources
-        self.pagearray.append(
-            IndirectPdfDict(
-                page,
-                Resources=inheritable.Resources,
-                MediaBox=inheritable.MediaBox,
-                CropBox=inheritable.CropBox,
-                Rotate=inheritable.Rotate,
-            )
+        newpage = IndirectPdfDict(
+            page,
+            Resources=inheritable.Resources,
+            MediaBox=inheritable.MediaBox,
+            CropBox=inheritable.CropBox,
+            Rotate=inheritable.Rotate,
         )
+        self.pagearray.append(newpage)
+        self.pagemap[id(page)] = newpage
 
         # Add parents in the hierarchy to objects we
         # don't want to output
@@ -313,7 +318,7 @@ class PdfWriter(object):
 
         try:
             FormatObjects(f, trailer, self.version, self.compress,
-                          self.killobj, user_fmt=user_fmt)
+                          self.killobj, self.pagemap, user_fmt=user_fmt)
         finally:
             if not preexisting:
                 f.close()


### PR DESCRIPTION
The PDF writer generates a new PdfIndirectDict for each page. However,
references to the original page object can remain in the object graph,
for example as link destinations. This results in a) nonfunctional links
and b) pulling unused trees into the document (duplicating the target pages).

This patch introduces a mapping from the original page numbers to the
new ones, and updates any references to point to the new page objects.
