### PR TITLE
Optimize tokenizer token memoization

### DIFF
--- a/pdfrw/py23_diffs.py
+++ b/pdfrw/py23_diffs.py
@@ -46,3 +46,8 @@ try:
     xrange = xrange
 except NameError:
     xrange = range
+
+try:
+    intern = intern
+except NameError:
+    from sys import intern


### PR DESCRIPTION
Pull separate memoization function into main function and optimize code paths.

Increases overall test performance by around 2% on my machine.