### PR TITLE
Allow PdfWriter() to be given a filename on instantiation

### DIFF
--- a/examples/4up.py
+++ b/examples/4up.py
@@ -27,7 +27,7 @@ def get4(srcpages):
 inpfn, = sys.argv[1:]
 outfn = '4up.' + os.path.basename(inpfn)
 pages = PdfReader(inpfn).pages
-writer = PdfWriter()
+writer = PdfWriter(outfn)
 for index in range(0, len(pages), 4):
     writer.addpage(get4(pages[index:index + 4]))
-writer.write(outfn)
+writer.write()

--- a/examples/alter.py
+++ b/examples/alter.py
@@ -19,6 +19,4 @@ outfn = 'alter.' + os.path.basename(inpfn)
 
 trailer = PdfReader(inpfn)
 trailer.Info.Title = 'My New Title Goes Here'
-writer = PdfWriter()
-writer.trailer = trailer
-writer.write(outfn)
+PdfWriter(outfn, trailer=trailer).write()

--- a/examples/booklet.py
+++ b/examples/booklet.py
@@ -53,4 +53,4 @@ while len(ipages) > 2:
 
 opages += ipages
 
-PdfWriter().addpages(opages).write(outfn)
+PdfWriter(outfn).addpages(opages).write()

--- a/examples/extract.py
+++ b/examples/extract.py
@@ -22,6 +22,6 @@ outfn = 'extract.' + os.path.basename(inpfn)
 pages = list(page_per_xobj(PdfReader(inpfn).pages, margin=0.5*72))
 if not pages:
     raise IndexError("No XObjects found")
-writer = PdfWriter()
+writer = PdfWriter(outfn)
 writer.addpages(pages)
-writer.write(outfn)
+writer.write()

--- a/examples/fancy_watermark.py
+++ b/examples/fancy_watermark.py
@@ -102,4 +102,4 @@ for pagenum, page in enumerate(trailer.pages, 1):
     PageMerge(page).add(wmark, prepend=underneath).render()
 
 # Write out the destination file
-PdfWriter().write(outfn, trailer)
+PdfWriter(outfn, trailer=trailer).write()

--- a/examples/poster.py
+++ b/examples/poster.py
@@ -37,7 +37,7 @@ def adjust(page, margin=36, scale=4.8):
 inpfn, = sys.argv[1:]
 outfn = 'poster.' + os.path.basename(inpfn)
 reader = PdfReader(inpfn)
-writer = PdfWriter()
+writer = PdfWriter(outfn)
 writer.addpage(adjust(reader.pages[0]))
 writer.trailer.Info = IndirectPdfDict(reader.Info or {})
-writer.write(outfn)
+writer.write()

--- a/examples/print_two.py
+++ b/examples/print_two.py
@@ -29,4 +29,4 @@ def fixpage(page, count=[0]):
 inpfn, = sys.argv[1:]
 outfn = 'print_two.' + os.path.basename(inpfn)
 pages = PdfReader(inpfn).pages
-PdfWriter().addpages(fixpage(x) for x in pages).write(outfn)
+PdfWriter(outfn).addpages(fixpage(x) for x in pages).write()

--- a/examples/rotate.py
+++ b/examples/rotate.py
@@ -36,6 +36,6 @@ for onerange in ranges:
         pages[pagenum].Rotate = (int(pages[pagenum].inheritable.Rotate or
                                      0) + rotate) % 360
 
-outdata = PdfWriter()
+outdata = PdfWriter(outfn)
 outdata.trailer = trailer
-outdata.write(outfn)
+outdata.write()

--- a/examples/subset.py
+++ b/examples/subset.py
@@ -20,10 +20,10 @@ assert ranges, "Expected at least one range"
 ranges = ([int(y) for y in x.split('-')] for x in ranges)
 outfn = 'subset.%s' % os.path.basename(inpfn)
 pages = PdfReader(inpfn).pages
-outdata = PdfWriter()
+outdata = PdfWriter(outfn)
 
 for onerange in ranges:
     onerange = (onerange + onerange[-1:])[:2]
     for pagenum in range(onerange[0], onerange[1]+1):
         outdata.addpage(pages[pagenum-1])
-outdata.write(outfn)
+outdata.write()

--- a/examples/subset_booklets.py
+++ b/examples/subset_booklets.py
@@ -57,5 +57,5 @@ while len(ipages) > 2:
 if len(ipages) >= 1:
     opages.append(fixpage(ipages.pop(), ipages.pop(0)))
 
-PdfWriter().addpages(opages).write(OUTFN)
+PdfWriter(OUTFN).addpages(opages).write()
 print 'It took '+ str(round(time.time()-START, 2))+' seconds to make the pdf subbooklets changes.'

--- a/examples/unspread.py
+++ b/examples/unspread.py
@@ -26,7 +26,7 @@ def splitpage(src):
 
 inpfn, = sys.argv[1:]
 outfn = 'unspread.' + os.path.basename(inpfn)
-writer = PdfWriter()
+writer = PdfWriter(outfn)
 for page in PdfReader(inpfn).pages:
     writer.addpages(splitpage(page))
-writer.write(outfn)
+writer.write()

--- a/examples/watermark.py
+++ b/examples/watermark.py
@@ -34,4 +34,4 @@ wmark = PageMerge().add(PdfReader(wmarkfn).pages[0])[0]
 trailer = PdfReader(inpfn)
 for page in trailer.pages:
     PageMerge(page).add(wmark, prepend=underneath).render()
-PdfWriter().write(outfn, trailer)
+PdfWriter(outfn, trailer=trailer).write()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -96,7 +96,7 @@ class TestOnePdf(unittest.TestCase):
                     os.remove(scrub)
                 subprocess.call(params)
                 if scrub:
-                    PdfWriter().addpages(PdfReader(scrub).pages).write(dstf)
+                    PdfWriter(dstf).addpages(PdfReader(scrub).pages).write()
             with open(dstf, 'rb') as f:
                 data = f.read()
             size = len(data)

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -79,11 +79,12 @@ class TestOnePdf(unittest.TestCase):
                     result = 'skip -- encrypt'
                     hash = '------skip-encrypt-no-file------'
                     return self.skipTest('File encrypted')
-                writer = pdfrw.PdfWriter(compress=compress)
+                writer = pdfrw.PdfWriter(dstf, compress=compress)
                 if repaginate:
                     writer.addpages(trailer.pages)
-                    trailer = None
-                writer.write(dstf, trailer)
+                else:
+                    writer.trailer = trailer
+                writer.write()
             with open(dstf, 'rb') as f:
                 data = f.read()
             size = len(data)


### PR DESCRIPTION
  - This will be required for later incremental PDF generation support
  - It makes the API more logical
  - This commit showcases the change by using it in various ways
    in the example programs.
  - This is a logical grouping of a few of the changes from the
    refactor_pdf branch.