### PR TITLE
Crypt filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
 install:
   - "pip install ."
   - "pip install reportlab || true"
+  - "pip install PyCrypto || true"
   - "pip install zlib || true"
   - "pip install unittest2 || true"
 # command to run tests

--- a/pdfrw/crypt.py
+++ b/pdfrw/crypt.py
@@ -1,0 +1,134 @@
+# A part of pdfrw (https://github.com/pmaupin/pdfrw)
+# Copyright (C) 2017  Jon Lund Steffensen
+# MIT license -- See LICENSE.txt for details
+
+from __future__ import division
+
+import hashlib
+import struct
+
+try:
+    from Crypto.Cipher import ARC4, AES
+    HAS_CRYPTO = True
+except ImportError:
+    HAS_CRYPTO = False
+
+from .objects import PdfDict
+
+_PASSWORD_PAD = (
+    '(\xbfN^Nu\x8aAd\x00NV\xff\xfa\x01\x08'
+    '..\x00\xb6\xd0h>\x80/\x0c\xa9\xfedSiz')
+
+
+def streamobjects(mylist, isinstance=isinstance, PdfDict=PdfDict):
+    for obj in mylist:
+        if isinstance(obj, PdfDict) and obj.stream is not None:
+            yield obj
+
+
+def create_key(password, doc):
+    """Create an encryption key (Algorithm 2 in PDF spec)."""
+    key_size = int(doc.Encrypt.Length or 40) // 8
+    padded_pass = (password + _PASSWORD_PAD)[:32]
+    hasher = hashlib.md5()
+    hasher.update(padded_pass)
+    hasher.update(doc.Encrypt.O.to_bytes())
+    hasher.update(struct.pack('<i', int(doc.Encrypt.P)))
+    hasher.update(doc.ID[0].to_bytes())
+    temp_hash = hasher.digest()
+
+    if int(doc.Encrypt.R or 0) >= 3:
+        for _ in range(50):
+            temp_hash = hashlib.md5(temp_hash[:key_size]).digest()
+
+    return temp_hash[:key_size]
+
+
+def create_user_hash(key, doc):
+    """Create the user password hash (Algorithm 4/5)."""
+    revision = int(doc.Encrypt.R or 0)
+    if revision < 3:
+        cipher = ARC4.new(key)
+        return cipher.encrypt(_PASSWORD_PAD)
+    else:
+        hasher = hashlib.md5()
+        hasher.update(_PASSWORD_PAD)
+        hasher.update(doc.ID[0].to_bytes())
+        temp_hash = hasher.digest()
+
+        for i in range(20):
+            temp_key = ''.join(chr(i ^ ord(x)) for x in key)
+            cipher = ARC4.new(temp_key)
+            temp_hash = cipher.encrypt(temp_hash)
+
+        return temp_hash
+
+
+def check_user_password(key, doc):
+    """Check that the user password is correct (Algorithm 6)."""
+    expect_user_hash = create_user_hash(key, doc)
+    revision = int(doc.Encrypt.R or 0)
+    if revision < 3:
+        return doc.Encrypt.U.to_bytes() == expect_user_hash
+    else:
+        return doc.Encrypt.U.to_bytes()[:16] == expect_user_hash
+
+
+class AESCryptFilter(object):
+    """Crypt filter corresponding to /AESV2."""
+    def __init__(self, key):
+        self._key = key
+
+    def decrypt_data(self, num, gen, data):
+        """Decrypt data (string/stream) using key (Algorithm 1)."""
+        key_extension = struct.pack('<i', num)[:3]
+        key_extension += struct.pack('<i', gen)[:2]
+        key_extension += 'sAlT'
+        temp_key = self._key + key_extension
+        temp_key = hashlib.md5(temp_key).digest()
+
+        iv = data[:AES.block_size]
+        cipher = AES.new(temp_key, AES.MODE_CBC, iv)
+        decrypted = cipher.decrypt(data[AES.block_size:])
+
+        # Remove padding
+        pad_size = ord(decrypted[-1])
+        assert 1 <= pad_size <= 16
+        return decrypted[:-pad_size]
+
+
+class RC4CryptFilter(object):
+    """Crypt filter corresponding to /V2."""
+    def __init__(self, key):
+        self._key = key
+
+    def decrypt_data(self, num, gen, data):
+        """Decrypt data (string/stream) using key (Algorithm 1)."""
+        new_key_size = min(len(self._key) + 5, 16)
+        key_extension = struct.pack('<i', num)[:3]
+        key_extension += struct.pack('<i', gen)[:2]
+        temp_key = self._key + key_extension
+        temp_key = hashlib.md5(temp_key).digest()[:new_key_size]
+
+        cipher = ARC4.new(temp_key)
+        return cipher.decrypt(data)
+
+
+class IdentityCryptFilter(object):
+    """Identity crypt filter (pass through with no encryption)."""
+    def decrypt_data(self, num, gen, data):
+        return data
+
+
+def decrypt_objects(default_filter, objects):
+    """Decrypt list of stream objects with the specified crypt filter."""
+    for obj in streamobjects(objects):
+        if getattr(obj, 'decrypted', False):
+            continue
+
+        # TODO: Use the /Crypt entry to decide on the final filter to use.
+        filter = default_filter
+
+        num, gen = obj.indirect
+        obj.stream = filter.decrypt_data(num, gen, obj.stream)
+        obj.private.decrypted = True

--- a/pdfrw/pdfreader.py
+++ b/pdfrw/pdfreader.py
@@ -19,6 +19,7 @@ from .errors import PdfParseError, log
 from .tokens import PdfTokens
 from .objects import PdfDict, PdfArray, PdfName, PdfObject, PdfIndirect
 from .uncompress import uncompress
+from . import crypt
 from .py23_diffs import convert_load, convert_store, iteritems
 
 
@@ -267,6 +268,10 @@ class PdfReader(PdfDict):
 
     def uncompress(self):
         self.read_all()
+
+        crypt_filter = self.stream_crypt_filter
+        crypt.decrypt_objects(crypt_filter, self.indirect_objects.values())
+
         uncompress(self.indirect_objects.values())
 
     def load_stream_objects(self, object_streams):
@@ -279,7 +284,13 @@ class PdfReader(PdfDict):
 
         # read objects from stream
         if objs:
+            # Decrypt
+            crypt_filter = self.stream_crypt_filter
+            crypt.decrypt_objects(crypt_filter, objs)
+
+            # Decompress
             uncompress(objs)
+
             for obj in objs:
                 objsource = PdfTokens(obj.stream, 0, False)
                 next = objsource.next
@@ -476,8 +487,66 @@ class PdfReader(PdfDict):
             log.error('Invalid page tree: %s' % s)
             return []
 
+    def _parse_encrypt_info(self, source, password, trailer):
+        """Check password and initialize crypt filters."""
+        # Create and check password key
+        if password is None:
+            key = crypt.create_key('', trailer)
+        else:
+            key = crypt.create_key(password, trailer)
+
+        if not crypt.check_user_password(key, trailer):
+            source.warning('User password does not validate')
+
+        # Create default crypt filters
+        private = self.private
+        crypt_filters = self.crypt_filters
+        version = int(trailer.Encrypt.V or 0)
+        if version in (1, 2):
+            crypt_filter = crypt.RC4CryptFilter(key)
+            private.stream_crypt_filter = crypt_filter
+            private.string_crypt_filter = crypt_filter
+        elif version == 4:
+            if PdfName.CF in trailer.Encrypt:
+                for name, params in iteritems(trailer.Encrypt.CF):
+                    if name == PdfName.Identity:
+                        continue
+
+                    cfm = params.CFM
+                    if cfm == PdfName.AESV2:
+                        crypt_filters[name] = crypt.AESCryptFilter(key)
+                    elif cfm == PdfName.V2:
+                        crypt_filters[name] = crypt.RC4CryptFilter(key)
+                    else:
+                        source.warning(
+                            'Unsupported crypt filter: {}, {}'.format(
+                                name, cfm))
+
+            # Read default stream filter
+            if PdfName.StmF in trailer.Encrypt:
+                name = trailer.Encrypt.StmF
+                if name in crypt_filters:
+                    private.stream_crypt_filter = crypt_filters[name]
+                else:
+                    source.warning(
+                        'Invalid crypt filter name in /StmF:'
+                        ' {}'.format(name))
+
+            # Read default string filter
+            if PdfName.StrF in trailer.Encrypt:
+                name = trailer.Encrypt.StrF
+                if name in crypt_filters:
+                    private.string_crypt_filter = crypt_filters[name]
+                else:
+                    source.warning(
+                        'Invalid crypt filter name in /StrF:'
+                        ' {}'.format(name))
+        else:
+            source.warning(
+                'Unsupported Encrypt version: {}'.format(version))
+
     def __init__(self, fname=None, fdata=None, decompress=False,
-                 disable_gc=True, verbose=True):
+                 password=None, disable_gc=True, verbose=True):
         self.private.verbose = verbose
 
         # Runs a lot faster with GC off.
@@ -554,6 +623,22 @@ class PdfReader(PdfDict):
                     break
                 xref_list.append((source.obj_offsets, trailer, is_stream))
                 source.floc = int(prev)
+
+            # Handle document encryption
+            identity_filter = crypt.IdentityCryptFilter()
+            crypt_filters = {
+                PdfName.Identity: identity_filter
+            }
+            private.crypt_filters = crypt_filters
+            private.stream_crypt_filter = identity_filter
+            private.string_crypt_filter = identity_filter
+
+            if PdfName.Encrypt in trailer:
+                if not crypt.HAS_CRYPTO:
+                    source.warning(
+                        'Install PyCrypto to enable encryption support')
+                else:
+                    self._parse_encrypt_info(source, password, trailer)
 
             if is_stream:
                 self.load_stream_objects(trailer.object_streams)


### PR DESCRIPTION
Implements decryption (#48) of streams in PDF files with encryption using the PyCrypto package. The correct crypt filter for string decryption is also made available to the user as `reader.string_crypt_filter` but is not applied automatically. If `decrypt` option is set, the objects will be decrypted (if necessary) before decompressing. This works on a couple of files that I have tested but there are probably files that won't work correctly. ~~In particular, only the global crypt filters are used for now, so if an object specifies a different crypt filter locally it won't work.~~ I had to set a flag on the decrypted `PdfDict`s in the `private` section to remember if it has already been decrypted, otherwise some objects would be twice decrypted when `decrypt` is set. I'm not sure if this is the best approach but it works.

~~The first commit is simply to support a default value on the `PdfDict` `get()` method (like the `dict` `get()` method). It is not strictly necessary but I think it simplifies the code in a few places.~~

~~When I run the round trip tests, a couple of version 1.3 PDFs seem to change hash. I think the difference in the output files is that some objects that were previously indirect objects are now inlined. None of the files that changed hash use encryption as far as I can tell. I'm not sure what exactly caused this change.~~