### PR TITLE
Fixed error in rotate.py example file

### DIFF
--- a/examples/rotate.py
+++ b/examples/rotate.py
@@ -36,6 +36,6 @@ for onerange in ranges:
         pages[pagenum].Rotate = (int(pages[pagenum].inheritable.Rotate or
                                      0) + rotate) % 360
 
-outdata = PdfWriter(outfn)
+outdata = PdfWriter()
 outdata.trailer = trailer
-outdata.write()
+outdata.write(outfn)


### PR DESCRIPTION
Output filename was being passed to creation of PdfWriter instead of PdfWriter write function.

Tested change in 2.7.12 and 3.5.2