### PR TITLE
Provide the `fname` positional argument

### DIFF
--- a/examples/booklet.py
+++ b/examples/booklet.py
@@ -53,4 +53,4 @@ while len(ipages) > 2:
 
 opages += ipages
 
-PdfWriter(outfn).addpages(opages).write()
+PdfWriter(outfn).addpages(opages).write(outfn)


### PR DESCRIPTION
Otherwise, running this script results in a `TypeError`:

```bash
Traceback (most recent call last):
  File "./booklet.py", line 56, in <module>
    PdfWriter(outfn).addpages(opages).write()
TypeError: write() missing 1 required positional argument: 'fname'
```

PS. Thank you for this awesome library. It's great.