### PR TITLE
Handle trailing NULLs after %%EOF

### DIFF
--- a/pdfrw/pdfreader.py
+++ b/pdfrw/pdfreader.py
@@ -334,7 +334,7 @@ class PdfReader(PdfDict):
         tableloc = source.next_default()
         if not tableloc.isdigit():
             source.exception('Expected table location')
-        if source.next_default().rstrip().lstrip('%') != 'EOF':
+        if source.next_default().rstrip("\x00\t\r\n ").lstrip('%') != 'EOF':
             source.exception('Expected %%EOF')
         return startloc, PdfTokens(fdata, int(tableloc), True, self.verbose)
 

--- a/pdfrw/pdfreader.py
+++ b/pdfrw/pdfreader.py
@@ -334,7 +334,7 @@ class PdfReader(PdfDict):
         tableloc = source.next_default()
         if not tableloc.isdigit():
             source.exception('Expected table location')
-        if source.next_default().rstrip("\x00\t\r\n ").lstrip('%') != 'EOF':
+        if source.next_default().rstrip("\x00 \t\n\r\x0b\x0c").lstrip('%') != 'EOF':
             source.exception('Expected %%EOF')
         return startloc, PdfTokens(fdata, int(tableloc), True, self.verbose)
 


### PR DESCRIPTION
I ran into a print printer whose output appends a bunch of NULL characters after the %%EOF marker in it's PDFs.  This tweaks PdfReader's EOF detector to ignore those like it does trailing whitespace.