### PR TITLE
[minor] fix PdfWritter + StringIO on python2

### DIFF
--- a/pdfrw/pdfwriter.py
+++ b/pdfrw/pdfwriter.py
@@ -242,7 +242,7 @@ class PdfWriter(object):
         if fname is not None:
             try:
                 float(fname)
-            except (ValueError, TypeError):
+            except (ValueError, TypeError, AttributeError):
                 pass
             else:
                 if version != '1.3':


### PR DESCRIPTION
Some file-like objects like python 2 `StringIO.StringIO` raise `AttributeError` when trying to convert them to float (more precisely `AttributeError: StringIO instance has no attribute '__float__'`).
This very minor PR should cover these cases and make in-memory PDF creation slightly easier on python2.

As an aside, both python 2 `cStringIO.StringIO` and python 3 `io.StringIO` seem to work.