### PR TITLE
Update Travis syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_install:
   - git clone https://github.com/pmaupin/static_pdfs tests/static_pdfs
   
 install:
-  - "pip install --only-binary=:all: --python-version $TRAVIS_PYTHON_VERSION -r requirements.txt"
-  - pip install .
+  - pip install --compile --requirement requirements.txt
+  - pip install --compile .
   
 # command to run tests
 script: "cd tests; /usr/bin/env PYTHONPATH=. py.test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,16 @@ python:
   - 3.8.2
   
 before_install:
-  - pip install --upgrade pip
+  - pip install --upgrade --compile pip
   - git clone https://github.com/pmaupin/static_pdfs tests/static_pdfs
   
 install:
-  - pip install pytest
+  - pip install --upgrade --compile pytest pytest-xdist
   - pip install --requirement requirements.txt
   - pip install .
   
 # command to run tests
-script: PYTHONPATH=. py.test
+script: PYTHONPATH=./tests pytest -n auto 
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,18 @@ python:
   - 3.6.10
   - 3.7.6
   - 3.8.2
-  - nightly
   
 before_install:
   - pip install --upgrade pip
   - git clone https://github.com/pmaupin/static_pdfs tests/static_pdfs
   
 install:
-  - pip install --compile --requirement requirements.txt
-  - pip install --compile .
+  - pip install pytest
+  - pip install --requirement requirements.txt
+  - pip install .
   
 # command to run tests
-script: "cd tests; /usr/bin/env PYTHONPATH=. py.test"
+script: PYTHONPATH=. py.test
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - git clone https://github.com/pmaupin/static_pdfs tests/static_pdfs
   
 install:
-  - pip install -r requirements.txt
+  - pip install --only-binary=:all: --python-version $TRAVIS_PYTHON_VERSION -r requirements.txt
   - pip install .
   
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ os: linux
 
 dist: bionic
 
+git:
+  depth: 1
+
 python:
   - 2.7
   - 3.6
@@ -11,7 +14,7 @@ python:
   - 3.8
 
 before_install:
-  - git lfs clone --depth 1 https://github.com/pmaupin/static_pdfs tests/static_pdfs
+  - git clone --depth 1 https://github.com/pmaupin/static_pdfs tests/static_pdfs
   
 install:
   - pip install pytest pytest-xdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,16 @@ os: linux
 dist: bionic
 
 python:
-  - 2.7.17
-  - 3.6.10
-  - 3.7.6
-  - 3.8.2
-  
+  - 2.7
+  - 3.6
+  - 3.7
+  - 3.8
+
 before_install:
-  - pip install --upgrade --compile pip
   - git clone https://github.com/pmaupin/static_pdfs tests/static_pdfs
   
 install:
-  - pip install --upgrade --compile pytest pytest-xdist
+  - pip install pytest pytest-xdist
   - pip install --requirement requirements.txt
   - pip install .
   
@@ -24,3 +23,6 @@ script: PYTHONPATH=./tests pytest -n auto
 
 cache:
   pip: true
+  directories:
+  - ./tests/static_pdfs
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
   - 3.8
 
 before_install:
-  - git clone https://github.com/pmaupin/static_pdfs tests/static_pdfs
+  - git clone --depth 1 https://github.com/pmaupin/static_pdfs tests/static_pdfs
   
 install:
   - pip install pytest pytest-xdist
@@ -24,5 +24,4 @@ script: PYTHONPATH=./tests pytest -n auto
 cache:
   pip: true
   directories:
-  - ./tests/static_pdfs
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,23 @@
 language: python
+
+os: linux
+
+dist: bionic
+
 python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "nightly"
-# command to install dependencies
+  - 2.7.17
+  - 3.6.10
+  - 3.7.6
+  - 3.8.2
+  - nightly
+  
 before_install:
-  - "git clone https://github.com/pmaupin/static_pdfs tests/static_pdfs"
+  - pip install --upgrade pip
+  - git clone https://github.com/pmaupin/static_pdfs tests/static_pdfs
+  
 install:
-  - "pip install ."
-  - "pip install reportlab || true"
-  - "pip install PyCrypto || true"
-  - "pip install zlib || true"
-  - "pip install unittest2 || true"
+  - pip install -r requirements.txt
+  - pip install .
+  
 # command to run tests
 script: "cd tests; /usr/bin/env PYTHONPATH=. py.test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ git:
   depth: 1
 
 python:
-  - 2.7
-  - 3.6
-  - 3.7
-  - 3.8
+  - 2.7.18
+  - 3.6.10
+  - 3.7.7
+  - 3.8.2
 
 before_install:
   - git clone --depth 1 https://github.com/pmaupin/static_pdfs tests/static_pdfs

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,6 @@ install:
   
 # command to run tests
 script: "cd tests; /usr/bin/env PYTHONPATH=. py.test"
+
+cache:
+  pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
   - 3.8
 
 before_install:
-  - git clone --depth 1 https://github.com/pmaupin/static_pdfs tests/static_pdfs
+  - git lfs clone --depth 1 https://github.com/pmaupin/static_pdfs tests/static_pdfs
   
 install:
   - pip install pytest pytest-xdist
@@ -23,5 +23,3 @@ script: PYTHONPATH=./tests pytest -n auto
 
 cache:
   pip: true
-  directories:
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - git clone https://github.com/pmaupin/static_pdfs tests/static_pdfs
   
 install:
-  - pip install --only-binary=:all: --python-version $TRAVIS_PYTHON_VERSION -r requirements.txt
+  - "pip install --only-binary=:all: --python-version $TRAVIS_PYTHON_VERSION -r requirements.txt"
   - pip install .
   
 # command to run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 reportlab
 PyCrypto
-zlib
 unittest2
+# zlib couldnt find this package

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+reportlab
+PyCrypto
+zlib
+unittest2


### PR DESCRIPTION
## This pull request updates the syntax of Travis configuration and creates a `requirements.txt` file

- Adds explicit operating system and distribution declaration

- Adds git depth declaration to turn checkout faster

- Pin the exact version of python

- Removes python 3.3, 3.4, 3.5 since they're not supported anymore

- Adds 3.7 and 3.8 versions

- Adds --depth 1  to the clone of the static pdfs

- Creates a requirements file to make sure the exact versions are installed

- Simplifies test command and introduces pytest

- Adds pip cache

