### PR TITLE
Fixing decodegraphics.py import error

### DIFF
--- a/examples/rl2/decodegraphics.py
+++ b/examples/rl2/decodegraphics.py
@@ -359,7 +359,7 @@ def findparsefuncs():
 
     dispatch = {}
     expected_args = 'self token params'.split()
-    for key, func in globals().items():
+    for key, func in list(globals().items()):
         if key.startswith('parse_'):
             args, varargs, keywords, defaults = getargspec(func)
             assert (args == expected_args and varargs is None and


### PR DESCRIPTION
Given this code:
```python
import os, pdfrw, sys
sys.path.append(os.path.join(os.path.dirname(pdfrw.__file__), '../examples'))
from rl2.decodegraphics import parsepage
```

This fix avoids the following error with Python 3.7:
```
Traceback (most recent call last):
  File "./extract_table.py", line 3, in <module>
    from rl2.decodegraphics import parsepage
  File "/opt/pdfrw/pdfrw/../examples/rl2/decodegraphics.py", line 377, in <module>
    class _ParseClass(object):
  File "/opt/pdfrw/pdfrw/../examples/rl2/decodegraphics.py", line 378, in _ParseClass
    dispatch = findparsefuncs()
  File "/opt/pdfrw/pdfrw/../examples/rl2/decodegraphics.py", line 362, in findparsefuncs
    for key, func in globals().items():
RuntimeError: dictionary changed size during iteration
```