### PR TITLE
DOC: Update PyPDF2 links / mentions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -686,9 +686,9 @@ Pure Python
     reportlab is must-have software if you want to programmatically
     generate arbitrary PDFs.
 
--  `pyPdf <https://github.com/mstamy2/PyPDF2>`__
+-  `pypdf <https://pypi.org/project/pypdf/>`__
 
-    pyPdf is, in some ways, very full-featured. It can do decompression
+    pypdf is, in some ways, very full-featured. It can do decompression
     and decryption and seems to know a lot about items inside at least
     some kinds of PDF files. In comparison, pdfrw knows less about
     specific PDF file features (such as metadata), but focuses on trying

--- a/pdfrw/__init__.py
+++ b/pdfrw/__init__.py
@@ -12,7 +12,7 @@ from .pagemerge import PageMerge
 
 __version__ = '0.4'
 
-# Add a tiny bit of compatibility to pyPdf
+# Add a tiny bit of compatibility to pyPdf / PyPDF2<1.28.0
 
 PdfFileReader = PdfReader
 PdfFileWriter = PdfWriter

--- a/pdfrw/pdfreader.py
+++ b/pdfrw/pdfreader.py
@@ -680,7 +680,7 @@ class PdfReader(PdfDict):
             if decompress:
                 self.uncompress()
 
-            # For compatibility with pyPdf
+            # For compatibility with pyPdf / PyPDF2<1.28.0
             private.numPages = len(self.pages)
         finally:
             if disable_gc:

--- a/pdfrw/pdfwriter.py
+++ b/pdfrw/pdfwriter.py
@@ -294,7 +294,7 @@ class PdfWriter(object):
             new_obj = None
         return self
 
-    addPage = addpage  # for compatibility with pyPdf
+    addPage = addpage  # for compatibility with pyPdf / PyPDF2<1.28.0
 
     def addpages(self, pagelist):
         for page in pagelist:


### PR DESCRIPTION
This PR updates an outdated link + mentions PyPDF2 (which is the only maintained version of pypdf).

I've just noticed that the interface of PyPDF2>=1.28.0 became more similar to pdfrw :-)